### PR TITLE
Update constants to match the reference implementation

### DIFF
--- a/MT19937.py
+++ b/MT19937.py
@@ -11,8 +11,8 @@ f = 1812433253
 # make a arry to store the state of the generator
 MT = [0 for i in range(n)]
 index = n+1
-lower_mask = 0xFFFFFFFF #int(bin(1 << r), 2) - 0b1
-upper_mask = 0x00000000 #int(str(-~lower_mask)[-w:])
+lower_mask = 0x7FFFFFFF #(1 << r) - 1 // That is, the binary number of r 1's
+upper_mask = 0x80000000 #lowest w bits of (not lower_mask)
 
 
 # initialize the generator from a seed
@@ -35,8 +35,8 @@ def extract_number():
 
     y = MT[index]
     y = y ^ ((y >> u) & d)
-    y = y ^ ((y << t) & c)
     y = y ^ ((y << s) & b)
+    y = y ^ ((y << t) & c)
     y = y ^ (y >> l)
 
     index += 1

--- a/RandomClass.py
+++ b/RandomClass.py
@@ -11,8 +11,8 @@ class Random():
         # make a arry to store the state of the generator
         self.MT = [0 for i in range(self.n)]
         self.index = self.n+1
-        self.lower_mask = 0xFFFFFFFF
-        self.upper_mask = 0x00000000
+        self.lower_mask = 0x7FFFFFFF
+        self.upper_mask = 0x80000000
         # inital the seed
         self.c_seed = c_seed
         self.seed(c_seed)
@@ -45,8 +45,8 @@ class Random():
 
         y = self.MT[self.index]
         y = y ^ ((y >> self.u) & self.d)
-        y = y ^ ((y << self.t) & self.c)
         y = y ^ ((y << self.s) & self.b)
+        y = y ^ ((y << self.t) & self.c)
         y = y ^ (y >> self.l)
 
         self.index += 1


### PR DESCRIPTION
I tried to use this code to replicate the output from a C implementation of Mersenne Twister and noticed that the values are different for the same seed.
After some debugging, I found two differences to the reference implementation and the [wikipedia pseudocode](https://en.wikipedia.org/wiki/Mersenne_Twister):
1. the lower_mask is usually defined as 0x7FFFFFFF and the upper_mask as 0x80000000 (which matches the description in wikipedia)
2. in the tempering part in extract_number(), the constants s, b and t, c are switched

It would be really nice if you could merge this, especially since the README claims `Coefficients follow the standard of MT19937-32.`